### PR TITLE
prevent remote console access by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following configuration options are available:
 | `grails.plugin.console.baseUrl`                  | Base URL for the console controller. Default uses createLink(). |
 | `grails.plugin.console.fileStore.remote.enabled` | Whether to include the remote file store functionality. Default is true. |
 | `grails.plugin.console.layout`                   | Used to override the plugin's GSP layout. |
+| `grails.plugin.console.remoteAccess.enabled`     | Whether to enable remote access to the console.  Default is false. |
 
 ## Security
 

--- a/test/unit/org/grails/plugins/console/ConsoleControllerSpec.groovy
+++ b/test/unit/org/grails/plugins/console/ConsoleControllerSpec.groovy
@@ -37,6 +37,38 @@ class ConsoleControllerSpec extends Specification {
         response.status != 404
     }
 
+    void 'beforeInterceptor - local request when remote access is disabled'() {
+        given:
+        config.grails.plugin.console.enabled = true
+        config.grails.plugin.console.remoteAccess.enabled = false
+
+        expect:
+        controller.beforeInterceptor() != false
+        response.status != 404
+    }
+
+    void 'beforeInterceptor - remote request when remote access is enabled'() {
+        given:
+        config.grails.plugin.console.enabled = true
+        config.grails.plugin.console.remoteAccess.enabled = true
+        controller.metaClass.isLocalRequest = { -> false }
+
+        expect:
+        controller.beforeInterceptor() != false
+        response.status != 404
+    }
+
+    void 'beforeInterceptor - remote request when remote access is disabled'() {
+        given:
+        config.grails.plugin.console.enabled = true
+        config.grails.plugin.console.remoteAccess.enabled = false
+        controller.metaClass.isLocalRequest = { -> false }
+
+        expect:
+        controller.beforeInterceptor() == false
+        response.status == 404
+    }
+
     void 'index'() {
         when:
         controller.index()


### PR DESCRIPTION
We all know it's super dangerous to have the console plugin running in an unintended environment.  The top-level enabled flag covers this pretty well.

But wherever the plugin is enabled, if someone has access to the grails app, they also have access to the console, and therefore have access to the OS and whatever privileges that java/tomcat have access to.  e.g. Other developers have access to other developers' machines unless there's a firewall in place.  The same security hole exists for any environment where the plugin is enabled.

It seems like a sensible default to deny remote access to the console unless explicitly enabled.  This would be a breaking change for people that are currently accessing the console remotely, but it would force them to be acknowledge the security threat.  For anyone that's newer to grails or unaware of this risk, it adds another layer of safety.
