### PR TITLE
Prevent execute from being called multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ The [1.X](https://grails.org/plugin/console) version is for Grails 2, while the 
 Add a dependency in BuildConfig.groovy:
 
 ```groovy
-runtime ':console:1.5.5'
+grails.project.dependency.resolution = {
+  // ...
+  plugins {
+    runtime ':console:1.5.5'
+    // ...
+  }
+}
 ```
 
 ### Grails 3

--- a/web/app/app.coffee
+++ b/web/app/app.coffee
@@ -134,7 +134,7 @@ Application = Backbone.Marionette.Application.extend
     $('body').css 'visibility', 'visible'
 
   _initKeybindings: ->
-    $(document).bind 'keydown', 'Ctrl+return Meta+return', => @execute 'execute'
+    $(document).bind 'keyup', 'Ctrl+return Meta+return', => @execute 'execute'
     $(document).bind 'keydown', 'Ctrl+s Meta+s', (event) =>
       event.preventDefault()
       event.stopPropagation()

--- a/web/app/app.coffee
+++ b/web/app/app.coffee
@@ -134,7 +134,7 @@ Application = Backbone.Marionette.Application.extend
     $('body').css 'visibility', 'visible'
 
   _initKeybindings: ->
-    $(document).bind 'keyup', 'Ctrl+return Meta+return', => @execute 'execute'
+    $(document).bind 'keypress', 'Ctrl+return Meta+return', => @execute 'execute'
     $(document).bind 'keydown', 'Ctrl+s Meta+s', (event) =>
       event.preventDefault()
       event.stopPropagation()


### PR DESCRIPTION
Keydown can allow double fire, which could be a problem for running execute commands. See [this article](http://www.quirksmode.org/dom/events/keys.html) for more information.
