### PR TITLE
bintrayPublishing.gradle was updated to use project properties to ove…

### DIFF
--- a/grails3/build.gradle
+++ b/grails3/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'idea'
 apply plugin: "spring-boot"
 apply plugin: "org.grails.grails-plugin"
 apply plugin: "org.grails.grails-gsp"
-// Used for publishing to central repository, remove if not needed
+
 apply from:'https://raw.githubusercontent.com/grails/grails-profile-repository/master/profiles/plugin/templates/grailsCentralPublishing.gradle'
 apply from:'https://raw.githubusercontent.com/grails/grails-profile-repository/master/profiles/plugin/templates/bintrayPublishing.gradle'
 
@@ -78,17 +78,3 @@ task repairPublicFiles(type: Copy) { // https://github.com/grails/grails-core/is
     into 'build/resources/main/static'
 }
 processResources.finalizedBy repairPublicFiles
-
-bintray {
-    pkg {
-        repo = 'grails-plugins'
-        userOrg = 'sheehan'
-        name = 'org.grails.plugins:console'
-        desc = 'Grails Console Plugin'
-        websiteUrl = 'https://grails.org/plugin/console'
-        issueTrackerUrl = 'https://github.com/sheehan/grails-console/issues'
-        vcsUrl = 'https://github.com/sheehan/grails-console'
-        licenses = ['Apache-2.0']
-        publicDownloadNumbers = true
-    }
-}

--- a/grails3/gradle.properties
+++ b/grails3/gradle.properties
@@ -1,2 +1,9 @@
 grailsVersion=3.0.1
 gradleWrapperVersion=2.3
+
+repo=grails-plugins
+userOrg=sheehan
+desc=Grails Console Plugin
+websiteUrl=https://github.com/sheehan/grails-console
+issueTrackerUrl=https://github.com/sheehan/grails-console/issues
+vcsUrl=https://github.com/sheehan/grails-console

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'console'


### PR DESCRIPTION
…rride defaults; removed the bintray block override and added overrides in gradle.properties. Also added a project name override in settings.gradle so the plugin doesn't have a redundant "grails-" prefix in the name